### PR TITLE
Fix status code. Add function to parse argv. Add a pipex tester

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,30 +68,30 @@ OBJ_UTILS = $(UTILS:.c=.o)
 # <-- Main Target --> #
 all: $(NAME)
 
-# <-- Compile Library --> #
-
 # <--Library Creation-->#
 $(NAME): $(OBJ_SRC) $(OBJ_UTILS)
-	make -C libft
-	@echo "$(B_GREEN)$(T_YELLOW)$(BOLD)Objects created successfully$(RESET)"
-	$(CC) $(CFLAGS) $(OBJ_SRC) $(OBJ_UTILS) -Llibft -lft -o $(NAME)
-	@echo "$(B_GREEN)$(T_YELLOW)$(BOLD)$(NAME) created successfully$(RESET)"
+	@make -s -C libft
+	@echo "✅ 🦔 $(T_YELLOW)$(BOLD)Objects $(RESET)$(T_GREEN)created successfully$(RESET)"
+	@$(CC) $(CFLAGS) $(OBJ_SRC) $(OBJ_UTILS) -Llibft -lft -o $(NAME)
+	@echo "✅ 🦔 $(T_MAGENTA)$(BOLD)$(NAME) $(RESET)$(T_GREEN)created successfully$(RESET)"
 
 # <-- Objects Creation --> #
 %.o: %.c
-	$(CC) $(CFLAGS) -c $< -o $@
+	@echo "🧩 🦔 $(T_WHITE)$(BOLD)Compiling $<...$(RESET)"
+	@$(CC) $(CFLAGS) -c $< -o $@
+	@echo "🔨 🦔 $(T_BLUE)$(BOLD)$@ $(RESET)$(T_GREEN)created!$(RESET)"
 
 # <-- Objects Destruction --> #
 clean:
-	@make clean -C libft
-	$(RM) $(OBJ_SRC) $(OBJ_UTILS)
-	@echo "$(B_RED)$(T_YELLOW)$(BOLD)Source Object destroyed successfully$(RESET)"
+	@make clean -s -C libft
+	@$(RM) $(OBJ_SRC) $(OBJ_UTILS)
+	@echo "🗑️  🦔 $(T_YELLOW)$(BOLD)Objects $(RESET)$(T_RED)destroyed successfully$(RESET)"
 
-# <- Clean Execution + Library Destruction -> #
+# <- Clean Execution + $(NAME) Destruction -> #
 fclean: clean
-	@make fclean -C libft
-	$(RM) $(NAME)
-	@echo "$(B_RED)$(T_YELLOW)$(BOLD)Library destroyed successfully$(RESET)"
+	@make fclean -s -C libft
+	@$(RM) $(NAME)
+	@echo "🗑️  🦔 $(T_MAGENTA)$(BOLD)$(NAME) $(RESET)$(T_RED)destroyed successfully$(RESET)"
 
 # <- Fclean Execution + All Execution -> #
 re: fclean all

--- a/src/pipex.c
+++ b/src/pipex.c
@@ -6,11 +6,25 @@
 /*   By: ribana-b <ribana-b@student.42malaga.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/22 14:49:56 by ribana-b          #+#    #+#             */
-/*   Updated: 2023/11/13 08:13:14 by ribana-b         ###   ########.fr       */
+/*   Updated: 2023/11/24 10:00:54 by ribana-b         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../include/pipex.h"
+
+static int	ft_argv_parser(int argc, char **argv)
+{
+	int	counter;
+
+	counter = 2;
+	while (argv[argc - counter] && (argc - counter) > 1)
+	{
+		if (!argv[argc - counter][0])
+			return (1);
+		counter++;
+	}
+	return (0);
+}
 
 int	pipex(int argc, char **argv, char **envp)
 {
@@ -18,7 +32,8 @@ int	pipex(int argc, char **argv, char **envp)
 	int		pipefd[2];
 	pid_t	pid;
 
-	status = 0;
+	if (ft_argv_parser(argc, argv) != 0)
+		ft_error_message("Empty command");
 	if (pipe(pipefd) < 0)
 		ft_error_message("pipe");
 	pid = fork();
@@ -31,7 +46,7 @@ int	pipex(int argc, char **argv, char **envp)
 		waitpid(pid, &status, WNOHANG);
 		status = ft_parent_process(argv, envp, pipefd, argc);
 	}
-	return (WEXITSTATUS(status));
+	return (status);
 }
 
 int	main(int argc, char **argv, char **envp)
@@ -40,8 +55,6 @@ int	main(int argc, char **argv, char **envp)
 
 	if (argc != 5)
 		return (1);
-	if (!argv[2][0] || !argv[3][0])
-		ft_error_message("command");
 	status = pipex(argc, argv, envp);
 	return (status);
 }

--- a/src/pipex.c
+++ b/src/pipex.c
@@ -6,7 +6,7 @@
 /*   By: ribana-b <ribana-b@student.42malaga.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/22 14:49:56 by ribana-b          #+#    #+#             */
-/*   Updated: 2023/10/26 00:06:01 by ribana-b         ###   ########.fr       */
+/*   Updated: 2023/11/13 08:13:14 by ribana-b         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,11 +24,11 @@ int	pipex(int argc, char **argv, char **envp)
 	pid = fork();
 	if (pid < 0)
 		ft_error_message("fork");
-	else if (pid == 0)
+	if (pid == 0)
 		ft_first_child_process(argv, envp, pipefd);
 	else
 	{
-		waitpid(pid, &status, 0);
+		waitpid(pid, &status, WNOHANG);
 		status = ft_parent_process(argv, envp, pipefd, argc);
 	}
 	return (WEXITSTATUS(status));
@@ -39,7 +39,9 @@ int	main(int argc, char **argv, char **envp)
 	int	status;
 
 	if (argc != 5)
-		return (0);
+		return (1);
+	if (!argv[2][0] || !argv[3][0])
+		ft_error_message("command");
 	status = pipex(argc, argv, envp);
 	return (status);
 }

--- a/tester.sh
+++ b/tester.sh
@@ -1,0 +1,265 @@
+#/bin/bash
+
+# Save current directory
+root=$(pwd)
+
+# Finished testing
+
+if [ $# -eq 1 ]; then
+	rm -rf $root/txt $root/test
+	printf "🗑️  🦔 \033[1;33mDirectories \033[0;31mremoved!\033[0m\n"
+	exit 0
+fi
+
+printf "\033[35m\
+==============================================================================================
+|\033[33m __________  __                             ___________                __                   \033[35m|
+|\033[33m \______   \|__|______    ____  ___  ___    \__    ___/____    _______/  |_   ____ _______  \033[35m|
+|\033[33m  |     ___/|  |\____ \ _/ __ \ \  \/  /      |    | _/ __ \  /  ___/\   __\_/ __ \\_  __  \ \033[35m|
+|\033[33m  |    |    |  ||  |_> >\  ___/  >    <       |    | \  ___/  \___ \  |  |  \  ___/ |  | \/ \033[35m|
+|\033[33m  |____|    |__||   __/  \___  >/__/\_ \      |____|  \___  >/____  > |__|   \___  >|__|    \033[35m|
+|\033[33m                |__|         \/       \/                  \/      \/             \/         \033[35m|
+==============================================================================================
+\033[0m"
+
+# Directory to save test outputs
+
+rm -rf $root/test
+printf "Creating \033[1;33mtest \033[0mdirectory...\n"
+mkdir $root/test
+
+# Directory to save txts
+
+rm -rf $root/txt
+printf "Creating \033[1;33mtxt \033[0mdirectory...\n"
+mkdir $root/txt
+
+# Generate txts
+echo "" > $root/txt/text1.txt
+
+printf "Hello world
+How are you doing these days?
+This is a test for pipex
+" > $root/txt/text2.txt
+
+printf "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789\n" > $root/txt/text3.txt
+
+printf "Testing absolute paths :O\n" > $root/txt/text4.txt
+
+printf "Invalid first command\n" > $root/txt/text5.txt
+
+printf "Invalid second command\n" > $root/txt/text6.txt
+
+printf "Invalid both command\n" > $root/txt/text6.txt
+
+printf "Empty first command\n" > $root/txt/text7.txt
+
+printf "Empty second command\n" > $root/txt/text8.txt
+
+printf "Empty both commands" > $root/txt/text9.txt
+
+# Go to pipex directory
+if [ ! $(echo "$root" | grep "pipex") ]; then
+	cd $root/pipex
+# Save git command path 
+	git=$(which git)
+	$git submodule update --init --recursive
+fi
+
+# Save make command path
+make=$(which make)
+$make -s
+
+# Check if valgrind exists
+valgrind=$(which valgrind)
+if [ $? -eq 0 ]; then
+	valgrind_installed=1
+else
+	valgrind_installed=0
+fi
+
+test_number=0
+
+# Test 1
+((test_number++))
+printf "\033[1;33mTest \033[31m$test_number\033[0m: "
+
+./pipex $root/txt/text${test_number}.txt cat echo $root/test/my_test${test_number}_output.txt
+echo $? >> $root/test/my_test${test_number}_output.txt
+#./pipex $root/txt/text2.txt "cat" "cat" $root/here.txt
+#echo $? >> $root/here.txt
+#echo "WTF" >> $root/here.txt
+#echo $? >> $root/here
+
+cat < $root/txt/text${test_number}.txt | echo > $root/test/og_test${test_number}_output.txt
+echo $? >> $root/test/og_test${test_number}_output.txt
+
+diff $root/test/my_test1_output.txt $root/test/og_test1_output.txt > /dev/null
+if [ $? -eq 0 ]; then
+	printf "\033[32mOK\033[0m"
+else
+	printf "\033[31mKO\033[0m\n"
+	exit 1
+fi
+
+if [ $valgrind_installed -eq 1 ]; then
+	$valgrind ./pipex $root/txt/text1.txt "cat -e" echo /dev/null 2>&1 | grep "LEAK SUMMARY" > /dev/null
+	if [ $? -eq 1 ]; then
+		printf " \033[32mMOK\033[0m\n"
+	else
+		printf " \033[31mMKO\033[0m\n"
+		exit 1
+	fi
+else
+	printf "\n"
+fi
+
+# Test 2
+((test_number++))
+printf "\033[1;33mTest \033[31m$test_number\033[0m: "
+
+./pipex $root/txt/text2.txt "cat -e" echo $root/test/my_test2_output.txt
+echo $? >> $root/test/my_test2_output.txt
+
+cat -e < $root/txt/text2.txt | echo > $root/test/og_test2_output.txt
+echo $? >> $root/test/og_test2_output.txt
+
+diff $root/test/my_test2_output.txt $root/test/og_test2_output.txt
+if [ $? -eq 0 ]; then
+	printf "\033[32mOK\033[0m"
+else
+	printf "\033[31mKO\033[0m\n"
+	exit 1
+fi
+
+if [ $valgrind_installed -eq 1 ]; then
+	$valgrind ./pipex $root/txt/text2.txt "cat -e" echo /dev/null 2>&1 | grep "LEAK SUMMARY" > /dev/null
+	if [ $? -eq 1 ]; then
+		printf " \033[32mMOK\033[0m\n"
+	else
+		printf " \033[31mMKO\033[0m\n"
+		exit 1
+	fi
+else
+	printf "\n"
+fi
+
+# Test 3
+((test_number++))
+printf "\033[1;33mTest \033[31m$test_number\033[0m: "
+
+./pipex $root/txt/text${test_number}.txt "cat -e" "wc -c" $root/test/my_test${test_number}_output.txt
+echo $? >> $root/test/my_test${test_number}_output.txt
+
+cat -e < $root/txt/text${test_number}.txt | wc -c > $root/test/og_test${test_number}_output.txt
+echo $? >> $root/test/og_test${test_number}_output.txt
+
+diff $root/test/my_test${test_number}_output.txt $root/test/og_test${test_number}_output.txt
+if [ $? -eq 0 ]; then
+	printf "\033[32mOK\033[0m"
+else
+	printf "\033[31mKO\033[0m\n"
+	exit 1
+fi
+
+if [ $valgrind_installed -eq 1 ]; then
+	$valgrind ./pipex $root/txt/text${test_number}.txt "cat -e" "wc -c" /dev/null 2>&1 | grep "LEAK SUMMARY" > /dev/null
+	if [ $? -eq 1 ]; then
+		printf " \033[32mMOK\033[0m\n"
+	else
+		printf " \033[31mMKO\033[0m\n"
+		exit 1
+	fi
+else
+	printf "\n"
+fi
+
+# Test 4
+((test_number++))
+printf "\033[1;33mTest \033[31m$test_number\033[0m: "
+
+./pipex $root/txt/text${test_number}.txt "/bin/cat -e" "wc -c" $root/test/my_test${test_number}_output.txt
+echo $? >> $root/test/my_test${test_number}_output.txt
+
+/bin/cat -e < $root/txt/text${test_number}.txt | wc -c > $root/test/og_test${test_number}_output.txt
+echo $? >> $root/test/og_test${test_number}_output.txt
+
+diff $root/test/my_test${test_number}_output.txt $root/test/og_test${test_number}_output.txt
+if [ $? -eq 0 ]; then
+	printf "\033[32mOK\033[0m"
+else
+	printf "\033[31mKO\033[0m\n"
+	exit 1
+fi
+
+if [ $valgrind_installed -eq 1 ]; then
+	$valgrind ./pipex $root/txt/text${test_number}.txt "/bin/cat -e" "wc -c" /dev/null 2>&1 | grep "LEAK SUMMARY" > /dev/null
+	if [ $? -eq 1 ]; then
+		printf " \033[32mMOK\033[0m\n"
+	else
+		printf " \033[31mMKO\033[0m\n"
+		exit 1
+	fi
+else
+	printf "\n"
+fi
+
+# Test 5
+((test_number++))
+printf "\033[1;33mTest \033[31m$test_number\033[0m: "
+
+./pipex $root/txt/text${test_number}.txt invent ls $root/test/my_test${test_number}_output.txt
+echo $? >> $root/test/my_test${test_number}_output.txt
+
+invent < $root/txt/text${test_number}.txt | ls > $root/test/og_test${test_number}_output.txt
+echo $? >> $root/test/og_test${test_number}_output.txt
+
+diff $root/test/my_test${test_number}_output.txt $root/test/og_test${test_number}_output.txt
+if [ $? -eq 0 ]; then
+	printf "\033[32mOK\033[0m"
+else
+	printf "\033[31mKO\033[0m\n"
+	exit 1
+fi
+
+if [ $valgrind_installed -eq 1 ]; then
+	$valgrind ./pipex $root/txt/text${test_number}.txt invent ls /dev/null 2>&1 | grep "LEAK SUMMARY" > /dev/null
+	if [ $? -eq 1 ]; then
+		printf " \033[32mMOK\033[0m\n"
+	else
+		printf " \033[31mMKO\033[0m\n"
+		exit 1
+	fi
+else
+	printf "\n"
+fi
+
+# Test 6
+((test_number++))
+printf "\033[1;33mTest \033[31m$test_number\033[0m: "
+
+./pipex $root/txt/text${test_number}.txt ls invent $root/test/my_test${test_number}_output.txt
+echo $? >> $root/test/my_test${test_number}_output.txt
+
+ls < $root/txt/text${test_number}.txt | invent > $root/test/og_test${test_number}_output.txt
+echo $? >> $root/test/og_test${test_number}_output.txt
+
+diff $root/test/my_test${test_number}_output.txt $root/test/og_test${test_number}_output.txt
+if [ $? -eq 0 ]; then
+	printf "\033[32mOK\033[0m"
+else
+	printf "\033[31mKO\033[0m\n"
+	exit 1
+fi
+
+if [ $valgrind_installed -eq 1 ]; then
+	$valgrind ./pipex $root/txt/text${test_number}.txt ls invent /dev/null 2>&1 | grep "LEAK SUMMARY" > /dev/null
+	if [ $? -eq 1 ]; then
+		printf " \033[32mMOK\033[0m\n"
+	else
+		printf " \033[31mMKO\033[0m\n"
+		exit 1
+	fi
+else
+	printf "\n"
+fi

--- a/utils/error.c
+++ b/utils/error.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   pipex_utils.c                                      :+:      :+:    :+:   */
+/*   error.c                                            :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
 /*   By: ribana-b <ribana-b@student.42malaga.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/22 15:33:32 by ribana-b          #+#    #+#             */
-/*   Updated: 2023/10/23 09:14:33 by ribana-b         ###   ########.fr       */
+/*   Updated: 2023/11/24 10:01:30 by ribana-b         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,5 +15,9 @@
 void	ft_error_message(const char *str)
 {
 	perror(str);
+	if (ft_strncmp(str, "execve", 6) == 0)
+		exit(127);
+	if (ft_strncmp(str, "path", 4) == 0)
+		exit(127);
 	exit(EXIT_FAILURE);
 }

--- a/utils/execute.c
+++ b/utils/execute.c
@@ -1,12 +1,12 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   path.c                                             :+:      :+:    :+:   */
+/*   execute.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ribana-b <ribana-b@student.42.fr>          +#+  +:+       +#+        */
+/*   By: ribana-b <ribana-b@student.42malaga.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/27 07:57:30 by ribana-b          #+#    #+#             */
-/*   Updated: 2023/10/27 07:57:57 by ribana-b         ###   ########.fr       */
+/*   Updated: 2023/11/13 09:09:06 by ribana-b         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,7 +38,12 @@ static void	ft_free_path(char **path)
 
 	i = 0;
 	while (path[i])
-		free(path[i++]);
+	{
+		free(path[i]);
+		path[i++] = NULL;
+	}
+	free(path);
+	path = NULL;
 	return ;
 }
 
@@ -51,8 +56,8 @@ char	*ft_find_path(char *command, char **envp)
 	i = 0;
 	while (ft_strncmp(envp[i], "PATH", 4) != 0 && envp[i] != NULL)
 		i++;
-	if (envp == NULL)
-		exit(EXIT_FAILURE);
+	if (envp[i] == NULL)
+		return (NULL);
 	path = ft_split(envp[i] + 5, ':');
 	i = 0;
 	while (path[i])
@@ -79,17 +84,23 @@ void	ft_execute_command(char *argv, char **envp)
 
 	i = 0;
 	command = ft_split(argv, ' ');
+	if (ft_strncmp(command[0], "/bin/", 5) == 0
+		|| ft_strncmp(command[0], "/usr/", 5) == 0)
+		if (execve(command[0], command, envp) == -1)
+			ft_error_message("execve");
 	path = ft_find_path(command[0], envp);
 	if (!path)
 	{
 		while (command[i])
-			free(command[i++]);
+		{
+			free(command[i]);
+			command[i++] = NULL;
+		}
 		free(command);
+		command = NULL;
 		ft_error_message("path");
 	}
 	if (execve(path, command, envp) == -1)
-	{
 		ft_error_message("execve");
-	}
 	return ;
 }

--- a/utils/process.c
+++ b/utils/process.c
@@ -6,7 +6,7 @@
 /*   By: ribana-b <ribana-b@student.42malaga.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/27 08:00:48 by ribana-b          #+#    #+#             */
-/*   Updated: 2023/11/13 07:39:50 by ribana-b         ###   ########.fr       */
+/*   Updated: 2023/11/24 09:57:29 by ribana-b         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,5 +63,5 @@ int	ft_parent_process(char **argv, char **envp, int *fd, int argc)
 		waitpid(pid, &status, 0);
 		close(fd[0]);
 	}
-	return (status);
+	return (WEXITSTATUS(status));
 }

--- a/utils/process.c
+++ b/utils/process.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   process.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: ribana-b <ribana-b@student.42malaga.com>   +#+  +:+       +#+        */
+/*   By: ribana-b <ribana-b@student.42malaga.com    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/27 08:00:48 by ribana-b          #+#    #+#             */
-/*   Updated: 2023/10/27 08:00:50 by ribana-b         ###   ########.fr       */
+/*   Updated: 2023/11/13 07:39:50 by ribana-b         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,7 +56,7 @@ int	ft_parent_process(char **argv, char **envp, int *fd, int argc)
 	close(fd[1]);
 	if (pid < 0)
 		ft_error_message("fork");
-	else if (pid == 0)
+	if (pid == 0)
 		ft_last_child_process(argv, envp, fd, argc);
 	else
 	{


### PR DESCRIPTION
- Hardcoded exit status code when the execve fails because the command does not exist.
- Added a function to parse argv because when it was hardcoded. Made it general so it'll work when I do bonus.
> NOTE The parser avoids a segfault in the child process when the path is not located.
- Added a pipex tester with some cases. To be improved.